### PR TITLE
add placeholder API for failing firebase tests

### DIFF
--- a/client/src/api/firebase/config.js
+++ b/client/src/api/firebase/config.js
@@ -2,16 +2,7 @@ import firebase from 'firebase/app';
 import 'firebase/storage';
 import 'firebase/auth';
 import 'firebase/firestore';
-
-const firebaseConfig = {
-  apiKey: process.env.REACT_APP_FIREBASE_API_KEY,
-  authDomain: process.env.REACT_APP_FIREBASE_AUTH_DOMAIN,
-  projectId: process.env.REACT_APP_FIREBASE_PROJECT_ID,
-  storageBucket: process.env.REACT_APP_FIREBASE_STORAGE_BUCKET,
-  messagingSenderId: process.env.REACT_APP_FIREBASE_MESSAGING_SENDER_ID,
-  appId: process.env.REACT_APP_FIREBASE_APP_ID,
-  measurementId: process.env.REACT_APP_FIREBASE_MEASUREMENT_ID,
-};
+import { firebaseConfig } from 'config';
 
 const app = firebase.initializeApp(firebaseConfig);
 export default app;

--- a/client/src/api/firebase/index.js
+++ b/client/src/api/firebase/index.js
@@ -1,8 +1,8 @@
-import account from './account/index.js';
-import cart from './cart/index.js';
-import logs from './logs/index.js';
-import saved from './saved/index.js';
-import suggested from './suggested/index.js';
+import account from './account';
+import cart from './cart';
+import logs from './logs';
+import saved from './saved';
+import suggested from './suggested';
 
 const firebaseAPI = {
   account,

--- a/client/src/config/index.js
+++ b/client/src/config/index.js
@@ -1,1 +1,10 @@
 export const FETCH_ITEM_LIMIT = 10;
+export const firebaseConfig = {
+  apiKey: process.env.REACT_APP_FIREBASE_API_KEY || 'placeholderAPIKey',
+  authDomain: process.env.REACT_APP_FIREBASE_AUTH_DOMAIN,
+  projectId: process.env.REACT_APP_FIREBASE_PROJECT_ID,
+  storageBucket: process.env.REACT_APP_FIREBASE_STORAGE_BUCKET,
+  messagingSenderId: process.env.REACT_APP_FIREBASE_MESSAGING_SENDER_ID,
+  appId: process.env.REACT_APP_FIREBASE_APP_ID,
+  measurementId: process.env.REACT_APP_FIREBASE_MEASUREMENT_ID,
+};

--- a/client/src/test-utils/index.js
+++ b/client/src/test-utils/index.js
@@ -11,6 +11,10 @@ import { createBrowserHistory } from 'history';
 import currentUser from 'currentUser';
 import '@testing-library/jest-dom';
 
+// Need to mock firebase? (try npm firebase-mock?)
+// https://stackoverflow.com/questions/52043886/how-do-you-mock-firebase-firestore-methods-using-jest
+// https://stackoverflow.com/questions/61686830/error-mocking-firebase-admin-in-jest-typeerror-admin-firestore-is-not-a-funct
+
 window.toTitleCase = str => {
   const result = str.replace(/([A-Z])/g, ' $1');
   return result.charAt(0).toUpperCase() + result.slice(1);


### PR DESCRIPTION
All tests are failing on Github actions because the API key is undefined.

Firebase configuration is trying to load, but the API is missing.