### PR TITLE
add queried products to state after search

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,9 +1,24 @@
-#
 # FIREBASE SETUP
 #   - (Sign up)
 #   - Create Project > Authentication > enable: "Email/Password"
 #   - Set up Firestore > Rules
 #      > add: match /users/{userId}/userCartLogs/cartItems/{document=**}
+#
+# UPDATE THE FIRESTORE RULES
+#
+# rules_version = '2';
+#
+# service cloud.firestore {
+#   match /databases/{database}/documents {
+#     // Allow only authenticated content owners access
+#     match /users/{userId}/{document=**} {
+#       allow read, write: if request.auth != null && request.auth.uid == userId;
+#     }
+#     match /products/{category}/{productDoc=**} {
+#         allow read: if request.auth != null;
+#     }
+#   }
+# }
 #
 REACT_APP_FIREBASE_API_KEY=
 REACT_APP_FIREBASE_AUTH_DOMAIN=

--- a/client/src/components/BrowseItems/BrowseItems.js
+++ b/client/src/components/BrowseItems/BrowseItems.js
@@ -28,6 +28,7 @@ const BrowseItems = ({ productsObj, isSavedProducts }) => {
   return (
     <div className={`browse-items ${classes.browseItems}`}>
       <SearchBar
+        searchingExternal={!isSavedProducts}
         searchMode={searchMode}
         searchFilter={searchFilter}
         setSearchMode={setSearchMode}

--- a/client/src/components/BrowseItems/ProductSearchResult/ProductSearchResult.js
+++ b/client/src/components/BrowseItems/ProductSearchResult/ProductSearchResult.js
@@ -9,7 +9,6 @@ const ProductSearchResult = ({ searchFilter, allProducts, isSavedProducts, sortM
   /* TAKE AN ARRAY OF PRODUCTS AND FILTER THEM */
   const searchRe = new RegExp(`${searchFilter}`, 'gi');
   let sortedList = allProducts.filter(product => (product['name'] || '').match(searchRe) || (product['brand'] || '').match(searchRe));
-  console.log(sortedList);
   if (sortMode && sortMode['sortBy'] && sortMode['orderBy']) {
     const keyMaps = {
       'Purchase Price': 'purchase_price',

--- a/client/src/components/BrowseItems/SearchBar/SearchBar.js
+++ b/client/src/components/BrowseItems/SearchBar/SearchBar.js
@@ -1,14 +1,21 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import SearchBarComponent from 'material-ui-search-bar';
+import useProducts from 'context/ProductsContext/ProductsContext';
 import SearchFilter from './SearchFilter/SearchFilter';
 import useStyles from './styles.js';
 
-const SearchBar = ({ searchMode, setSearchMode, setSearchFilter, searchFilter, sortMode, setSortMode }) => {
+const SearchBar = ({ searchingExternal, searchMode, setSearchMode, setSearchFilter, searchFilter, sortMode, setSortMode }) => {
   const classes = useStyles();
+  const { searchExternalProducts, searchSavedProducts } = useProducts();
 
   const handleSearch = () => {
     setSearchMode(true);
+    if (searchingExternal) {
+      searchExternalProducts(searchFilter);
+    } else {
+      searchSavedProducts(searchFilter);
+    }
   };
 
   const handleCancel = () => {
@@ -38,6 +45,7 @@ const SearchBar = ({ searchMode, setSearchMode, setSearchFilter, searchFilter, s
 export default SearchBar;
 
 SearchBar.propTypes = {
+  searchingExternal: PropTypes.bool.isRequired,
   searchMode: PropTypes.bool.isRequired,
   setSearchMode: PropTypes.func.isRequired,
   searchFilter: PropTypes.string.isRequired,

--- a/client/src/context/ProductsContext/ProductsContext.js
+++ b/client/src/context/ProductsContext/ProductsContext.js
@@ -95,17 +95,17 @@ export function ProductsProvider({ children }) {
   }
 
   function extendExistingProduct(newProduct, setProductList) {
-    const { categoryID, productId } = newProduct;
-    if (categoryID && productId && setProductList) {
+    const { category: categoryID, _id: productId } = newProduct;
+    if ((categoryID || 'other') && productId && setProductList) {
       setProductList(prevProducts => {
         const obj = { ...prevProducts };
-        const existingProduct = obj[categoryID][productId];
-        if (existingProduct) {
-          obj[categoryID][productId] = {
-            ...existingProduct,
-            ...newProduct,
-          };
-        }
+        const existingProduct = obj[categoryID][productId] || {};
+
+        obj[categoryID || 'other'][productId] = {
+          ...existingProduct,
+          ...newProduct,
+        };
+
         return obj;
       });
     }
@@ -115,8 +115,8 @@ export function ProductsProvider({ children }) {
     setLoading(true);
     spoonacularApi.fetchProductDetails(productId, nutritionObj => {
       const updatedValues = {
-        productId,
-        categoryID,
+        _id: productId,
+        category: categoryID,
         nutritionFacts: nutritionObj,
       };
 
@@ -131,6 +131,26 @@ export function ProductsProvider({ children }) {
     });
   }
 
+  function searchSavedProducts(query) {
+    setLoading(true);
+    savedItemData.queryDatabase(query, docList => {
+      docList.forEach(product => {
+        extendExistingProduct(product, setSavedProducts);
+      });
+      setLoading(false);
+    });
+  }
+
+  function searchExternalProducts(query) {
+    setLoading(true);
+    productsItemData.queryDatabase(query, docList => {
+      docList.forEach(product => {
+        extendExistingProduct(product, setExternalProducts);
+      });
+      setLoading(false);
+    });
+  }
+
   const value = {
     loading,
     fetchCategoryDocs,
@@ -140,6 +160,8 @@ export function ProductsProvider({ children }) {
     externalProducts,
     deleteSavedProduct,
     getNutritionDetails,
+    searchExternalProducts,
+    searchSavedProducts,
   };
 
   return <ProductsContext.Provider value={value}>{children}</ProductsContext.Provider>;

--- a/client/src/context/ProductsContext/ProductsContext.test.js
+++ b/client/src/context/ProductsContext/ProductsContext.test.js
@@ -38,6 +38,14 @@ describe('ProductsContext', () => {
       key: 'getNutritionDetails',
       targetInstance: Function,
     },
+    {
+      key: 'searchSavedProducts',
+      targetInstance: Function,
+    },
+    {
+      key: 'searchExternalProducts',
+      targetInstance: Function,
+    },
   ];
 
   testContextExports(ProductsProvider, useProducts, expectedExports);


### PR DESCRIPTION
## ⚠️ STATE doesn't store ALL products 
 - Start with 10 (config/FETCH_LIMIT) items in the category browser.
 - User should be able to SEARCH all products from SAVED or EXTERNAL products
 - Searching should QUERY the database to find MORE products with that name, to ADD to state

## User wants "Pork Chops" 
 - **Meat** category does not have "Pork Chops" in the top 10 items shown.
<img width="618" alt="Screen Shot 2021-09-18 at 3 29 47 PM" src="https://user-images.githubusercontent.com/60903378/133910120-546bc222-abc7-4435-9ea0-a3ba7ca25850.png">


## User searchs "Pork Chops" 
 - QUERIES the database, and now pork chops will show up

<img width="656" alt="Screen Shot 2021-09-18 at 3 35 42 PM" src="https://user-images.githubusercontent.com/60903378/133910197-b4150987-979a-4199-9813-63167382b810.png">

## Meat Category now has "Pork Chops"

<img width="643" alt="Screen Shot 2021-09-18 at 3 36 14 PM" src="https://user-images.githubusercontent.com/60903378/133910208-5552a38b-d9c8-41b0-814d-19d01d3a9980.png">

